### PR TITLE
WIP: Added more features to History page

### DIFF
--- a/src/qml/CalculationPage.qml
+++ b/src/qml/CalculationPage.qml
@@ -36,7 +36,7 @@ Kirigami.Page {
     leftPadding: 0
     rightPadding: 0
     bottomPadding: 0
-    
+    property alias result: inputPad.expression
     property color dropShadowColor: Qt.darker(Kirigami.Theme.backgroundColor, 1.15)
     property int keypadHeight: {
         let rows = 4, columns = 3;

--- a/src/qml/HistoryView.qml
+++ b/src/qml/HistoryView.qml
@@ -47,6 +47,9 @@ Kirigami.ScrollablePage {
         model: historyManager
         delegate: Kirigami.AbstractListItem {
             highlighted: false
+            onClicked:{
+                switchToPage("qrc:/qml/CalculationPage.qml");
+            }
             Text {
                 font.pointSize: Kirigami.Theme.defaultFont.pointSize * 2
                 color: Kirigami.Theme.activeTextColor

--- a/src/qml/HistoryView.qml
+++ b/src/qml/HistoryView.qml
@@ -48,7 +48,7 @@ Kirigami.ScrollablePage {
         delegate: Kirigami.AbstractListItem {
             highlighted: false
             onClicked:{
-                switchToPage("qrc:/qml/CalculationPage.qml");
+                pageStack.push("qrc:/qml/CalculationPage.qml", {"result":model.display.split('=')[0]});
             }
             Text {
                 font.pointSize: Kirigami.Theme.defaultFont.pointSize * 2


### PR DESCRIPTION
Clicking on an entry in the history page redirects to the calculation page and the entry is displayed on the screen.
Only the part before the '=' sign is added for user ease.