### PR TITLE
Fix: Correctly handle locale-specific decimal separators

### DIFF
--- a/src/qalculateengine.cpp
+++ b/src/qalculateengine.cpp
@@ -43,6 +43,11 @@ QString QalculateEngine::evaluate(QString &expression, bool *isApproximate, cons
 {
     CALCULATOR->abort();
 
+    const QChar decimalPoint = QLocale().decimalPoint().at(0);
+    if (decimalPoint != QLatin1Char('.')) {
+        expression.replace(decimalPoint, QLatin1Char('.'));
+    }
+
     if (QStringLiteral("+−-×÷/^").contains(expression.right(1))) {
         expression.truncate(expression.size() - 1);
     }
@@ -117,7 +122,7 @@ QString QalculateEngine::evaluate(QString &expression, bool *isApproximate, cons
         m_result.replace(QStringLiteral(" + "), HAIR_SPACE.toString());
     }
 
-    m_result.replace(QLatin1Char('.'), QLocale().decimalPoint(), Qt::CaseInsensitive);
+    m_result.replace(QLatin1Char('.'), decimalPoint, Qt::CaseInsensitive);
 
     return m_result;
 }


### PR DESCRIPTION
Fixes a bug where locales that use a comma for decimals, like de_DE, would break calculations. The comma wasn't being converted to a period for the math engine, leading to it being misinterpreted and causing weird results. This now handles the conversion before and after the calculation.

Fixes: https://bugs.kde.org/show_bug.cgi?id=507525